### PR TITLE
Support for input parameter in clozure

### DIFF
--- a/dev/openmcl.lisp
+++ b/dev/openmcl.lisp
@@ -13,7 +13,7 @@
             (process-exit-code process))))
 
 (defun create-shell-process (command wait &optional input)
-  (with-input-from-string (input-stream (or input nil))
+  (with-input-from-string (input-stream input)
    (ccl:run-program
     *bourne-compatible-shell*
     (list "-c" command)


### PR DESCRIPTION
Hi,

clozure accepts a stream for its input.
I create an input-stream from the string and feed that to ccl:run-program. That appears to do the trick.

Greetings,

Christian
