### PR TITLE
Fix error on Clozure CL

### DIFF
--- a/dev/openmcl.lisp
+++ b/dev/openmcl.lisp
@@ -13,7 +13,7 @@
             (process-exit-code process))))
 
 (defun create-shell-process (command wait &optional input)
-  (with-input-from-string (input-stream input)
+  (with-input (input-stream (or input :none))
    (ccl:run-program
     *bourne-compatible-shell*
     (list "-c" command)


### PR DESCRIPTION
Hi,

The trivial-shell:shell-command didn't work on ccl.

? (trivial-shell:shell-command "ls")

> Error: The value NIL is not of the expected type ARRAY.
> While executing: CCL::ARRAY-DATA-AND-OFFSET, in process listener(1).
> Type :POP to abort, :R for a list of available restarts.
> Type :? for other options.
> 1 > 

So I've fix it.
Would you consider pulling the branch fix-error-on-ccl on ktateish/trivial-shell .
