### PR TITLE
Extend OS-PROCESS-ID implemetations and export it

### DIFF
--- a/dev/clisp.lisp
+++ b/dev/clisp.lisp
@@ -10,7 +10,7 @@
    (ext:run-shell-command  command :output :terminal :wait t)))
 
 (defun %os-process-id ()
-  (error 'unsupported-function-error :function 'os-process-id))
+  (system::process-id))
 
 (defun %get-env-var (name)
   (ext:getenv name))

--- a/dev/cmucl.lisp
+++ b/dev/cmucl.lisp
@@ -9,13 +9,16 @@
          (error (file-to-string-as-lines (ext::process-error process))))
     (close (ext::process-output process))
     (close (ext::process-error process))
-    
+
     (values
      output
      error
      (ext::process-exit-code process))))
 
 (defun %os-process-id ()
+  #+unix
+  (unix:unix-getpid)
+  #-unix
   (error 'unsupported-function-error :function 'os-process-id))
 
 (defun %get-env-var (name)

--- a/dev/ecl.lisp
+++ b/dev/ecl.lisp
@@ -4,7 +4,7 @@
   (error 'unsupported-function-error :function 'shell-command))
 
 (defun %os-process-id ()
-  (error 'unsupported-function-error :function 'os-process-id))
+  (ext:getpid))
 
 (defun %get-env-var (name)
   (ext:getenv name))

--- a/dev/lispworks.lisp
+++ b/dev/lispworks.lisp
@@ -16,6 +16,9 @@
       (close output))))
 
 (defun %os-process-id ()
+  #+(or unix windows)
+  (system::getpid)
+  #-(or unix windows)
   (error 'unsupported-function-error :function 'os-process-id))
 
 (defun %get-env-var (name)

--- a/dev/openmcl.lisp
+++ b/dev/openmcl.lisp
@@ -2,7 +2,7 @@
 
 (defun %shell-command (command input)
   (let* ((process (create-shell-process command t input))
-         (output (file-to-string-as-lines 
+         (output (file-to-string-as-lines
                   (ccl::external-process-output-stream process)))
          (error (file-to-string-as-lines
                  (ccl::external-process-error-stream process))))
@@ -27,7 +27,7 @@
   (nth-value 1 (ccl:external-process-status process)))
 
 (defun %os-process-id ()
-  (error 'unsupported-function-error :function 'os-process-id))
+  (ccl::getpid))
 
 (defun %get-env-var (name)
   (ccl::getenv name))

--- a/dev/package.lisp
+++ b/dev/package.lisp
@@ -3,13 +3,14 @@
 (defpackage #:trivial-shell
   (:use #:common-lisp #:com.metabang.trivial-timeout)
   (:nicknames #:com.metabang.trivial-shell #:metashell)
-  (:export 
+  (:export
    #:shell-command
    #:with-timeout
    #:get-env-var
    #:exit
    #:*bourne-compatible-shell*
    #:*shell-search-paths*
+   #:os-process-id
 
    ;; conditions
    #:timeout-error
@@ -17,7 +18,7 @@
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (import
-   #+allegro 
+   #+allegro
    '(mp:process-wait-with-timeout)
    #+clisp
    '()

--- a/dev/sbcl.lisp
+++ b/dev/sbcl.lisp
@@ -6,7 +6,7 @@
     (let* ((process (sb-ext:run-program
                      *bourne-compatible-shell*
                      (list "-c" command)
-		     :wait nil :input input-stream 
+		     :wait nil :input input-stream
 		     :output :stream
 		     :error :stream))
 	   (output-thread (sb-thread:make-thread
@@ -39,7 +39,7 @@
 		(sb-ext:run-program
 		 *bourne-compatible-shell*
 		 (list "-c" (format nil "~a > ~a 2> ~a"
-				    command 
+				    command
 				    (namestring output)
 				    (namestring error)))
 		 :wait t
@@ -81,6 +81,9 @@
   (sb-ext:process-exit-code process))
 
 (defun %os-process-id ()
+  #+unix
+  (sb-unix:unix-getpid)
+  #-unix
   (error 'unsupported-function-error :function 'os-process-id))
 
 (defun %get-env-var (name)


### PR DESCRIPTION
Taken from [cl-mongo-driver](https://github.com/archimag/mongo-cl-driver/blob/82e56a390aa14cf642904740fb13c797568610a2/bson/types.lisp#L51).

Also exported the `os-process-id` symbol.