### PR TITLE
Fix package issue with sb-thread

### DIFF
--- a/dev/package.lisp
+++ b/dev/package.lisp
@@ -3,7 +3,7 @@
 (defpackage #:trivial-shell
   (:use #:common-lisp #:com.metabang.trivial-timeout)
   (:nicknames #:com.metabang.trivial-shell #:metashell)
-  (:export 
+  (:export
    #:shell-command
    #:with-timeout
    #:get-env-var
@@ -17,7 +17,7 @@
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (import
-   #+allegro 
+   #+allegro
    '(mp:process-wait-with-timeout)
    #+clisp
    '()
@@ -34,8 +34,8 @@
    #+(or openmcl ccl)
    '(ccl:process-wait-with-timeout)
    #+(and sbcl sb-threads)
-   '(sb-threads:make-semaphore
-     sb-threads:signal-semaphore)
+   '(sb-thread:make-semaphore
+     sb-thread:signal-semaphore)
    #+(and sbcl (not sb-threads))
    '()
    '#:trivial-shell))

--- a/trivial-shell-test.asd
+++ b/trivial-shell-test.asd
@@ -4,24 +4,20 @@ Author: Gary King
 See file COPYING for details
 |#
 
-(defpackage #:trivial-shell-test-system (:use #:cl #:asdf))
-(in-package #:trivial-shell-test-system)
-
-(defsystem trivial-shell-test
+(defsystem "trivial-shell-test"
   :author "Gary Warren King <gwking@metabang.com>"
   :maintainer "Gary Warren King <gwking@metabang.com>"
   :licence "MIT Style License"
   :description "Tests for trivial-shell"
-  :components ((:module 
+  :components ((:module
 		"setup"
 		:pathname "tests/"
-		:components 
+		:components
 		((:file "package")
 		 (:file "tests" :depends-on ("package"))))
-	       (:module 
+	       (:module
 		"tests"
 		:depends-on ("setup")
 		:components ((:file "test-timeout"))))
-  :depends-on (:lift :trivial-shell))
-
-
+  :depends-on ("lift" "trivial-shell")
+  :perform (test-op (o c) (symbol-call :lift '#:run-tests) :config :generic))

--- a/trivial-shell.asd
+++ b/trivial-shell.asd
@@ -7,10 +7,7 @@ Alexander Repenning's Apple event code. It was then subjected to bursts
 of gamma radiation and repeated does of the sonic screwdriver.
 |#
 
-(defpackage :trivial-shell-system (:use #:cl #:asdf))
-(in-package :trivial-shell-system)
-
-(defsystem trivial-shell
+(defsystem "trivial-shell"
   :version "0.2.0"
   :author "Gary Warren King <gwking@metabang.com>"
   :maintainer "Gary Warren King <gwking@metabang.com>"
@@ -71,7 +68,7 @@ of gamma radiation and repeated does of the sonic screwdriver.
 
 		 #-(or abcl allegro clisp cmu digitool ecl
 		       lispworks openmcl sbcl scl)
-		 (:file "unsupported")                                     
+		 (:file "unsupported")
 		 #+digitool
 		 (:module "mcl"
 			  :components ((:file "eval-apple-script")))))
@@ -80,16 +77,4 @@ of gamma radiation and repeated does of the sonic screwdriver.
 		:components
 		((:module "source"
 			  :components ((:static-file "index.md"))))))
-  :in-order-to ((test-op (load-op trivial-shell-test)))
-  :perform (test-op :after (op c)
-		    (funcall
-		      (intern (symbol-name '#:run-tests) :lift)
-		      :config :generic))
-  :depends-on ())
-
-(defmethod operation-done-p 
-           ((o test-op)
-            (c (eql (find-system 'trivial-shell))))
-  (values nil))
-
-
+  :in-order-to ((test-op (test-op "trivial-shell-test"))))


### PR DESCRIPTION
Also, cleanup .asd files to ASDF 3 recommended practice.

PS: I believe that trivial-shell functionality is fully subsumed by ASDF 3.0's uiop:run-program and now ASDF 3.2's asynchronous uiop:launch-program, which are more portable. This may or may not warrant a note in your README, and/or a warning in a `:perform (load-op :after (o c) (warn ...))`
